### PR TITLE
Refactor to separate register/guard methods

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "plugins": [
+    "transform-async-to-generator",
     "transform-function-bind",
     "transform-object-rest-spread",
     "transform-es2015-modules-commonjs"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "mocha": "^2.2.5",
     "should": "^7.0.2",
     "sinon": "^1.17.2",
+    "babel-plugin-transform-async-to-generator": "^6.16.0",
     "babel-plugin-transform-function-bind": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "preversion": "npm test",
     "postversion": "npm run build-docs && git push && git push --tags",
     "test": "NODE_ENV=test mocha --compilers js:babel-register -R spec test/*.js src/modules/**/test/*.js",
-    "compile": "babel src --out-dir lib; npm run copyTemplates",
+    "compile": "rm -r lib/; babel src --out-dir lib; npm run copyTemplates",
     "copyTemplates": "for each in `ls src/modules/`; do if [ -d src/modules/$each/templates ]; then cp -r src/modules/$each/templates lib/modules/$each; fi; done;",
     "prepublish": "npm run compile",
     "build-docs": "export NAME=`npm view . name`; export VERSION=`npm view . version`; documentation readme ./src/*.js --name $NAME --project-version $VERSION --readme-file ./README.md -s $NAME",

--- a/src/modules/users-permissions/index.js
+++ b/src/modules/users-permissions/index.js
@@ -43,7 +43,7 @@ class UsersPermissions extends HasModels {
    * Register a permission
    * @param {string} name Permission name
    * @param {string|array} [defaultRoles] Default role name(s) to contain this permission
-   * @param {object} [objectModel] Collection of ObjectRoleModel for object permissions
+   * @param {object} [objectModel] Collection of ObjectRoleModel for object permissions, or function (objectId, user) to return the roles a user has for a given object
    */
   register(name, defaultRoles=null, objectModel=null) {
     this._permissions[name] = {
@@ -68,6 +68,7 @@ class UsersPermissions extends HasModels {
    * @param {function|string} [handler|route] A handler or route to wrap with a permission check
    * @param {string} name Permission name
    * @param {object} [objectParam] URL param for object permissions object key
+   * @returns {function} Wrapped handler for method handlers
    */
   guard(handler, name, objectParam=null) {
     if (_.isString(handler)) {
@@ -84,6 +85,7 @@ class UsersPermissions extends HasModels {
    * @param {function|string} [handler|route] A handler or route to wrap with a permission check
    * @param {object} [objectParams] Mapping of req params to ObjectRoleModel identity
    * @param {string|array} [roleName] Default role name(s) to contain this permission
+   * @returns {function} Wrapped handler for method handlers
    */
   allow(name, handler = null, objectParams = null, roleName = null) {
     let coll, param
@@ -152,9 +154,13 @@ class UsersPermissions extends HasModels {
   async _setObjectRoles(user, permission, objectId) {
     let objectModel = this._permissions[permission].objectModel
     if (!objectModel) return
-    
-    let model = await storage.getModel(objectModel)
-    let roles = await model.find({user: user.id, object: objectId}).populate('role')
+    let roles
+    if (_.isString(objectModel)) {
+      let model = await storage.getModel(objectModel)
+      roles = await model.find({user: user.id, object: objectId}).populate('role')
+    } else {
+      roles = await objectModel(objectId, user)
+    }
     user.permissions.addRoles(_.pluck(roles, 'role'), objectId)
   }
 

--- a/src/modules/users-permissions/index.js
+++ b/src/modules/users-permissions/index.js
@@ -31,7 +31,7 @@ class UsersPermissions extends HasModels {
 
   _createRoles() {
     return Promise.map(_.keys(this._defaultRoles), async (role) => {
-      let roleOb = await this.models.Role.createOrUpdate({role}, {role, systemDefined: true})
+      let roleObj = await this.models.Role.createOrUpdate({role}, {role, systemDefined: true})
       this.log.info("Created role", role)
       roleObj.permissions = _.union(roleObj.permissions || [], this._defaultRoles[role])
       return roleObj.save()

--- a/src/modules/users-permissions/index.js
+++ b/src/modules/users-permissions/index.js
@@ -46,6 +46,7 @@ class UsersPermissions extends HasModels {
    * @param {object} [objectModel] Collection of ObjectRoleModel for object permissions, or function (objectId, user) to return the roles a user has for a given object
    */
   register(name, defaultRoles=null, objectModel=null) {
+    this.log.info("Registering permission", name, "for", defaultRoles, objectModel)
     this._permissions[name] = {
       name,
       objectModel,
@@ -90,8 +91,8 @@ class UsersPermissions extends HasModels {
   allow(name, handler = null, objectParams = null, roleName = null) {
     let coll, param
     if (objectParams) {
-      coll = _.first(_.keys(objectParams))
-      param = objectParams[coll]
+      param = _.first(_.keys(objectParams))
+      coll = objectParams[param]
     }
     this.register(name, roleName, coll)
     return this.guard(handler, name, param)

--- a/src/modules/users-permissions/test/index.js
+++ b/src/modules/users-permissions/test/index.js
@@ -82,4 +82,19 @@ describe("Users Permissions", () => {
       res.status.called.should.be.false
     })
   })
+  describe("Register", () => {
+    it("should register name", () => {
+      module.register("test-register")
+      module._permissions.should.have.property("test-register")
+    })
+    it("should register objectModel", () => {
+      module.register("test-register", null, 'one')
+      module._permissions['test-register'].should.have.property('objectModel', 'one')
+    })
+    it("should register roles", () => {
+      module.register("test-register", ["One", "Two"])
+      module._defaultRoles.should.have.property("One")
+      module._defaultRoles.should.have.property("Two")
+    })
+  })
 });

--- a/src/modules/users-permissions/test/index.js
+++ b/src/modules/users-permissions/test/index.js
@@ -97,4 +97,17 @@ describe("Users Permissions", () => {
       module._defaultRoles.should.have.property("Two")
     })
   })
+  describe("Guard", () => {
+    it("should guard route", () => {
+      module.guard("/route", 'test-register')
+      let match = module._routesPermissions.match("/route")
+      match.should.have.property("route", "/route")
+      let x = match.fn()
+      x.should.have.property("length", 2)
+    })
+    it("should guard handler", () => {
+      let x = module.guard(() => {}, 'test-register')
+      x.should.be.a("function")
+    })
+  })
 });

--- a/src/modules/users-permissions/test/index.js
+++ b/src/modules/users-permissions/test/index.js
@@ -106,7 +106,7 @@ describe("Users Permissions", () => {
       x.should.have.property("length", 2)
     })
     it("should guard handler", () => {
-      let x = module.guard(() => {}, 'test-register')
+      let x = module.guardHandler(() => {}, 'test-register')
       x.should.be.a("function")
     })
   })


### PR DESCRIPTION
Resolves #33 

The object permissions lookup (`objectModel` param to `register`) can now take a function that performs a manual lookup of the object roles - needed for routes where the route parameter is a child/related object to the role lookup assignments.