### PR TITLE
Add option to always respond to protectedRoutes with 403 rather than redirect

### DIFF
--- a/test/Users.js
+++ b/test/Users.js
@@ -62,6 +62,20 @@ describe("Users", () => {
       //console.log(res.redirect.firstCall.args)
       res.redirect.calledWith('/test/login?redirect=%2F').should.be.true
     })
+    it("middleware matches neverRedirect, anon gives 403", () => {
+      let res = stubRes()
+      module.protectedRoute('/authed', true)
+      module._ensureAuthenticated(Object.assign({path: '/authed'}, anonReq), res)
+      res.redirect.notCalled.should.be.true
+      res.status.calledWith(403).should.be.true
+    })
+    it("protectedServiceRoute is a synonym for neverRedirect option", () => {
+      let res = stubRes()
+      module.protectedServiceRoute('/authed')
+      module._ensureAuthenticated(Object.assign({path: '/authed'}, anonReq), res)
+      res.redirect.notCalled.should.be.true
+      res.status.calledWith(403).should.be.true
+    })
     it("middleware matches, anon xhr gives 403", () => {
       let res = stubRes()
       module.protectedRoute('/authed')

--- a/test/Users.js
+++ b/test/Users.js
@@ -88,4 +88,24 @@ describe("Users", () => {
       next.calledOnce.should.be.true
     })
   })
+  describe("adminRoute", () => {
+    beforeEach(() => {
+      module = new Users()
+    })
+    it("middleware matches, anon redirects", () => {
+      let res = stubRes()
+      module.ensureAdmin('/admin')
+      module._ensureAdmin(Object.assign({path: '/admin'}, anonReq), res)
+      //console.log(res.redirect.firstCall.args)
+      res.redirect.calledWith('/test/login?redirect=%2F').should.be.true
+    })
+    it("middleware matches, non-admin errors", () => {
+      let res = stubRes()
+      module.ensureAdmin('/admin')
+      module._ensureAdmin(Object.assign({path: '/admin', user: {admin: false}}, authReq), res)
+      //console.log(res.redirect.firstCall.args)
+      res.redirect.notCalled.should.be.true
+      res.status.calledWith(403).should.be.true
+    })
+  })
 });


### PR DESCRIPTION
@davidkellerman for managed-service case, with your simplification of route checking from there

Adds tests for all of these route middlewares.