### PR TITLE
Stripped HTML tags from plain-text version of user welcome email.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "passport": "^0.2.1",
     "passport-local": "^1.0.0",
     "routes": "^2.1.0",
+    "striptags": "^3.1.1",
     "underscore": "^1.7.0"
   },
   "homepage": "https://github.com/nxus/users#readme"

--- a/src/modules/users-welcome-email/index.js
+++ b/src/modules/users-welcome-email/index.js
@@ -1,3 +1,5 @@
+import striptags from 'striptags'
+
 import {application, NxusModule} from 'nxus-core'
 import {storage} from 'nxus-storage'
 import {mailer} from 'nxus-mailer'
@@ -16,6 +18,11 @@ export default class UsersWelcomeEmail extends NxusModule {
     })
   }
 
+  /* `users-user` model create event listener to send welcome email to user.
+   * It renders the `user-welcome-email` template to provide the body of
+   * the welcome email. The rendered result provides HTML message
+   * content, and is stripped of HTML tags to provide plaintext content.
+   */
   _sendWelcomeEmail(model, user) {
     this.log.debug('Sending welcome email to', user.email)
     var link
@@ -27,9 +34,9 @@ export default class UsersWelcomeEmail extends NxusModule {
 
     let tempPass = user.tempPassword
     delete user.tempPassword
-    templater.render('user-welcome-email', {user, tempPass, link, siteName: application.config.siteName}).then((content) => {
+    templater.render('user-welcome-email', {user, tempPass, link, siteName: application.config.siteName}).then((html) => {
       let fromEmail = (application.config.users && application.config.users.forgotPasswordEmail) ? application.config.users.forgotPasswordEmail : "noreply@"+((application.config.mailer && application.config.mailer.emailDomain) || application.config.host)
-      return mailer.send(user.email, fromEmail, "Welcome to "+application.config.siteName, content, {html: content})
+      return mailer.send(user.email, fromEmail, "Welcome to "+application.config.siteName, striptags(html), {html})
     })
   }
   


### PR DESCRIPTION
The rendered `user-welcome-email` template was being used for both HTML and plain-text versions of the multi-part user welcome email. With this change, the rendered content provides the fully-formatted HTML version, and is transformed into a fallback plain-text version by stripping out the HTML tags.